### PR TITLE
Improve CLI help formatting and add detailed documentation with examples

### DIFF
--- a/crates/ember-cli/src/commands/chat.rs
+++ b/crates/ember-cli/src/commands/chat.rs
@@ -1,8 +1,39 @@
-//! Chat command implementation.
+//! Chat command implementation for Ember CLI.
 //!
-//! This module provides both simple chat and full agent mode with tools.
-//! When tools are enabled via --tools flag, the agent can execute shell commands,
-//! filesystem operations, and web requests.
+//! This module powers the `ember chat` command and supports two modes:
+//!
+//! 1. **Simple Chat Mode**
+//!    - Direct interaction with an AI model
+//!    - Supports streaming responses
+//!
+//! 2. **Agent Mode (with tools)**
+//!    - Enables AI to execute tools automatically
+//!    - Available tools:
+//!        • shell       – run shell commands
+//!        • filesystem  – read/write files
+//!        • web         – fetch web pages
+//!
+//! ## Examples
+//!
+//! Basic chat:
+//! ```bash
+//! ember chat "Explain Rust ownership"
+//! ```
+//!
+//! Interactive chat:
+//! ```bash
+//! ember chat
+//! ```
+//!
+//! Using tools:
+//! ```bash
+//! ember chat --tools shell,filesystem
+//! ```
+//!
+//! Custom model:
+//! ```bash
+//! ember chat --model gpt-4
+//! ```
 
 use crate::config::AppConfig;
 use anyhow::{Context, Result};
@@ -116,7 +147,29 @@ impl ProgressIndicator {
     }
 }
 
-/// Run the chat command.
+
+
+
+/// Execute the `ember chat` command.
+///
+/// This function determines whether to run:
+/// - **Simple chat mode** (no tools)
+/// - **Agent mode** (tools enabled)
+///
+/// Behavior:
+/// - If a message is provided → one-shot response
+/// - If no message is provided → interactive session
+///
+/// # Arguments
+///
+/// - `config` – Loaded application configuration
+/// - `message` – Optional message for one-shot chat
+/// - `provider` – LLM provider override
+/// - `model` – Model override
+/// - `system` – Custom system prompt
+/// - `temperature` – Sampling temperature
+/// - `streaming` – Enable streaming output
+/// - `tools` – Optional list of tools to enable
 pub async fn run(
     config: AppConfig,
     message: Option<String>,
@@ -194,7 +247,18 @@ pub async fn run(
     Ok(())
 }
 
-/// Create a tool registry with the specified tools.
+
+
+/// Build a registry of enabled tools.
+///
+/// The registry is used by the agent to discover and execute tools.
+/// Supported tools:
+///
+/// - `shell` → run shell commands
+/// - `filesystem` → file operations
+/// - `web` → fetch web content
+///
+/// Invalid tools are ignored with a warning.
 fn create_tool_registry(tool_names: &[String]) -> Result<ToolRegistry> {
     let mut registry = ToolRegistry::new();
 
@@ -230,6 +294,8 @@ fn create_tool_registry(tool_names: &[String]) -> Result<ToolRegistry> {
     Ok(registry)
 }
 
+
+
 /// Create an LLM provider based on configuration and provider name.
 fn create_provider(config: &AppConfig, provider_name: &str) -> Result<Arc<dyn LLMProvider>> {
     match provider_name {
@@ -262,7 +328,16 @@ fn create_provider(config: &AppConfig, provider_name: &str) -> Result<Arc<dyn LL
     }
 }
 
-/// Run a task and exit.
+
+
+/// Execute a single AI task and exit.
+///
+/// This command is optimized for scripting and automation.
+///
+/// Example:
+/// ```bash
+/// ember run "Write a bash script that backs up files"
+/// ```
 pub async fn run_task(config: AppConfig, task: String, model: Option<String>) -> Result<()> {
     let provider_name = config.provider.default.clone();
 
@@ -400,7 +475,17 @@ async fn agent_one_shot(
     Ok(())
 }
 
-/// Agent interactive mode: chat with tool support.
+
+
+/// Interactive agent mode with tool execution.
+///
+/// In this mode the AI can automatically:
+///
+/// - run shell commands
+/// - read/write files
+/// - fetch web content
+///
+/// Tool usage is displayed inline in the terminal.
 async fn agent_interactive(
     provider: Arc<dyn LLMProvider>,
     model: &str,
@@ -689,7 +774,18 @@ async fn one_shot_chat(
     Ok(())
 }
 
-/// Interactive chat mode (no tools).
+
+
+/// Start interactive chat mode.
+///
+/// Users can continuously send prompts and receive responses.
+/// Special commands available during chat:
+///
+/// - `/help`    – show commands
+/// - `/clear`   – reset conversation
+/// - `/history` – show conversation history
+/// - `/model`   – show active model
+/// - `/exit`    – exit chat
 async fn interactive_chat(
     provider: Arc<dyn LLMProvider>,
     model: &str,

--- a/crates/ember-cli/src/commands/config.rs
+++ b/crates/ember-cli/src/commands/config.rs
@@ -1,10 +1,58 @@
-//! Configuration command implementations.
+//! Configuration command implementations for Ember CLI.
+//!
+//! This module provides commands to manage the Ember configuration file.
+//!
+//! The configuration stores settings such as:
+//! - default LLM provider
+//! - model settings
+//! - API keys
+//! - agent behavior
+//! - enabled tools
+//!
+//! Configuration is stored in a TOML file in the user's config directory.
+//!
+//! Examples:
+//!
+//! Initialize configuration:
+//! ```bash
+//! ember config init
+//! ```
+//!
+//! Show configuration:
+//! ```bash
+//! ember config show
+//! ```
+//!
+//! Set a value:
+//! ```bash
+//! ember config set provider.default openai
+//! ```
+//!
+//! Get a value:
+//! ```bash
+//! ember config get provider.default
+//! ```
 
 use crate::config::AppConfig;
 use anyhow::{Context, Result};
 use colored::Colorize;
 
-/// Initialize a new configuration file.
+
+
+/// Initialize a new Ember configuration file.
+///
+/// This creates a default configuration file if one does not exist.
+///
+/// Example:
+/// ```bash
+/// ember config init
+/// ```
+///
+/// Use `--force` to overwrite an existing configuration:
+///
+/// ```bash
+/// ember config init --force
+/// ```
 pub fn init(force: bool) -> Result<()> {
     let config_path = AppConfig::config_path()?;
 
@@ -49,7 +97,18 @@ pub fn init(force: bool) -> Result<()> {
     Ok(())
 }
 
-/// Show current configuration.
+
+
+
+/// Display the current configuration.
+///
+/// Shows provider settings, agent configuration,
+/// and enabled tools in a readable format.
+///
+/// Example:
+/// ```bash
+/// ember config show
+/// ```
 pub fn show(config: &AppConfig) -> Result<()> {
     println!("{}", "Ember Configuration".bright_yellow().bold());
     println!();
@@ -142,7 +201,15 @@ pub fn show(config: &AppConfig) -> Result<()> {
     Ok(())
 }
 
-/// Set a configuration value.
+
+
+/// Set a configuration key to a new value.
+///
+/// Example:
+/// ```bash
+/// ember config set provider.default ollama
+/// ember config set agent.temperature 0.7
+/// ```
 pub fn set(key: &str, value: &str) -> Result<()> {
     let mut config = AppConfig::load(None)?;
 
@@ -162,7 +229,14 @@ pub fn set(key: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
-/// Get a configuration value.
+
+
+/// Retrieve a configuration value.
+///
+/// Example:
+/// ```bash
+/// ember config get provider.default
+/// ```
 pub fn get(config: &AppConfig, key: &str) -> Result<()> {
     match config.get(key) {
         Some(value) => {
@@ -183,7 +257,15 @@ pub fn get(config: &AppConfig, key: &str) -> Result<()> {
     Ok(())
 }
 
-/// Show configuration file path.
+
+
+
+/// Display the location of the Ember configuration file.
+///
+/// Example:
+/// ```bash
+/// ember config path
+/// ```
 pub fn path() -> Result<()> {
     let config_path = AppConfig::config_path()?;
 
@@ -201,7 +283,12 @@ pub fn path() -> Result<()> {
     Ok(())
 }
 
-/// Print available configuration keys.
+
+
+/// Print all supported configuration keys.
+///
+/// This helps users discover valid keys when using
+/// `ember config set` or `ember config get`.
 fn print_available_keys() {
     let keys = [
         ("provider.default", "Default LLM provider (openai, ollama)"),

--- a/crates/ember-cli/src/commands/serve.rs
+++ b/crates/ember-cli/src/commands/serve.rs
@@ -1,4 +1,29 @@
 //! Web server command implementation.
+//!
+//! This module powers the `ember serve` command which starts
+//! an HTTP API server for the Ember AI agent.
+//!
+//! The server allows Ember to be accessed by:
+//! - web frontends
+//! - external tools
+//! - integrations
+//!
+//! Examples:
+//!
+//! Start the server on default port:
+//! ```bash
+//! ember serve
+//! ```
+//!
+//! Start server on a custom port:
+//! ```bash
+//! ember serve --port 8080
+//! ```
+//!
+//! Serve a frontend directory:
+//! ```bash
+//! ember serve --static-dir ./frontend
+//! ```
 
 use anyhow::Result;
 use clap::Args;
@@ -7,20 +32,49 @@ use tracing::info;
 /// Serve command arguments
 #[derive(Args, Debug)]
 pub struct ServeArgs {
-    /// Port to listen on
-    #[arg(short, long, default_value = "3000")]
+    #[arg(
+        short,
+        long,
+        default_value = "3000",
+        help = "Port for the HTTP server",
+        long_help = "Port for the HTTP server.
+
+Examples:
+  ember serve --port 8080
+  ember serve --port 5000"
+    )]
     pub port: u16,
 
-    /// Host to bind to
-    #[arg(long, default_value = "0.0.0.0")]
+    #[arg(
+        long,
+        default_value = "0.0.0.0",
+        help = "Host address to bind the server",
+        long_help = "Host address to bind the server.
+
+Examples:
+  ember serve --host 127.0.0.1
+  ember serve --host 0.0.0.0"
+    )]
     pub host: String,
 
-    /// Path to static files directory (for frontend)
-    #[arg(long)]
+    #[arg(
+        long,
+        help = "Directory containing static frontend files",
+        long_help = "Directory containing static frontend files.
+
+Examples:
+  ember serve --static-dir ./frontend
+  ember serve --static-dir ./dist"
+    )]
     pub static_dir: Option<String>,
 }
 
-/// Run the web server
+/// Start the Ember web server.
+///
+/// This launches the HTTP API used by Ember.
+/// Optionally serves static frontend files if `--static-dir` is provided.
+///
+/// The server will listen on the specified host and port.
 pub async fn run(args: ServeArgs) -> Result<()> {
     info!(
         host = %args.host,

--- a/crates/ember-cli/src/main.rs
+++ b/crates/ember-cli/src/main.rs
@@ -28,11 +28,37 @@ mod tui;
 use commands::{chat, config as config_cmd, serve};
 use config::AppConfig;
 
-/// Ember - Blazing fast AI agent in Rust
+/// Ember CLI - AI assistant for your terminal.
+///
+/// Examples:
+///   ember chat "Hello world"
+///   ember chat --model gpt-4
+///   ember run "Explain Rust ownership"
+///   ember config init
+///   ember serve
 #[derive(Parser)]
-#[command(name = "ember")]
-#[command(author, version, about, long_about = None)]
+#[command(
+    name = "ember",
+    author,
+    version,
+    about = "Blazing fast AI agent CLI written in Rust",
+    long_about = "Ember is a command-line AI assistant that lets you interact with
+large language models directly from the terminal.
+
+Features:
+• Interactive AI chat
+• Run AI tasks from the command line
+• Manage configuration easily
+• Start an HTTP server for integrations",
+    after_help = "Examples:
+  ember chat \"Explain Rust ownership\"
+  ember chat --model gpt-4
+  ember run \"Write a Python script\"
+  ember config init
+  ember serve"
+)]
 #[command(propagate_version = true)]
+#[command(arg_required_else_help = true)]
 struct Cli {
     /// Enable verbose logging
     #[arg(short, long, global = true)]
@@ -52,7 +78,24 @@ enum Commands {
     #[cfg(feature = "tui")]
     Tui,
 
-    /// Chat with the AI agent
+    #[command(
+        about = "Chat with the AI assistant.",
+        long_about = "Start a conversation with an AI model using Ember.
+
+You can send a single message for a one-shot response or run the command
+without arguments to enter interactive chat mode.
+
+Supports multiple providers (OpenAI, Ollama), custom models,
+system prompts, temperature control, and optional tool usage.
+
+Use the --tools flag to enable agent mode, allowing the AI to execute
+shell commands, access the filesystem, and fetch web content.",
+        after_help = "Examples:
+  ember chat \"Explain Rust ownership\"
+  ember chat --model gpt-4
+  ember chat --provider ollama
+  ember chat --tools shell,filesystem"
+    )]
     Chat {
         /// Message to send (omit for interactive mode)
         message: Option<String>,
@@ -82,7 +125,11 @@ enum Commands {
         tools: Option<Vec<String>>,
     },
 
-    /// Run a single command and exit
+    /// Execute a task using the AI agent and exit.
+    ///
+    /// Examples:
+    ///   ember run "Write a Python script"
+    ///   ember run "Explain async Rust"
     Run {
         /// The task to execute
         task: String,
@@ -92,7 +139,24 @@ enum Commands {
         model: Option<String>,
     },
 
-    /// Manage configuration
+    #[command(
+        about = "Manage Ember configuration.",
+        long_about = "Manage and customize Ember's configuration settings.
+
+The configuration file stores preferences such as:
+- default LLM provider (OpenAI or Ollama)
+- model settings
+- API keys
+- agent behavior and tools
+
+You can initialize a new config file, view current settings,
+or update individual configuration values.",
+        after_help = "Examples:
+  ember config init
+  ember config show
+  ember config set provider.default ollama
+  ember config get provider.default"
+    )]
     Config {
         #[command(subcommand)]
         action: ConfigAction,
@@ -101,7 +165,7 @@ enum Commands {
     /// Show version and system information
     Info,
 
-    /// Start the web server
+    /// Start Ember's HTTP server for API access.
     Serve(serve::ServeArgs),
 }
 
@@ -139,13 +203,11 @@ enum ConfigAction {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Initialize logging
     init_logging(cli.verbose)?;
 
-    // Load configuration
-    let config = AppConfig::load(cli.config.as_deref()).context("Failed to load configuration")?;
+    let config = AppConfig::load(cli.config.as_deref())
+        .context("Failed to load configuration")?;
 
-    // Execute command
     match cli.command {
         #[cfg(feature = "tui")]
         Commands::Tui => {
@@ -208,7 +270,6 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Initialize logging based on verbosity level.
 fn init_logging(verbose: bool) -> Result<()> {
     let filter = if verbose {
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"))
@@ -224,7 +285,6 @@ fn init_logging(verbose: bool) -> Result<()> {
     Ok(())
 }
 
-/// Print version and system information.
 fn print_info() -> Result<()> {
     println!("{}", "Ember AI Agent".bright_yellow().bold());
     println!();
@@ -252,7 +312,6 @@ fn print_info() -> Result<()> {
     Ok(())
 }
 
-/// Get rustc version (compile-time).
 fn rustc_version() -> &'static str {
     env!("CARGO_PKG_RUST_VERSION")
 }


### PR DESCRIPTION
## Summary

This PR improves the CLI help output and documentation for the Ember CLI by adding detailed descriptions and properly formatted examples for all commands.

## Changes

- Added detailed `long_about` descriptions for the `chat` and `config` commands.
- Added `after_help` sections to provide clean multi-line examples.
- Ensured at least **2 examples per command** for:
  - `ember --help`
  - `ember chat --help`
  - `ember serve --help`
  - `ember config --help`
- Improved readability and formatting of CLI help output.
- Enabled `arg_required_else_help` for better CLI UX (shows help when no command is provided).
- Cleaned up spacing and removed duplicated default value descriptions.

## Commands Improved

- Root CLI (`ember`)
- `chat`
- `serve`
- `config`

## Testing

Verified help output manually using:

cargo run -- --help
cargo run -- chat --help
cargo run -- serve --help
cargo run -- config --help

All commands now display:
- clear descriptions
- properly formatted options
- multiple usage examples

## Result

The CLI help output is now more readable, consistent, and user-friendly, following a more standard "man-page" style format.

Fixes #6


## ember --help
<img width="1112" height="788" alt="image" src="https://github.com/user-attachments/assets/87b52b3c-450e-4142-a347-6d7cd050bc93" />

## ember chat --help
<img width="900" height="791" alt="image" src="https://github.com/user-attachments/assets/a048bf4c-886e-43c8-9526-5681f2075a66" />

## ember config --help
<img width="798" height="585" alt="image" src="https://github.com/user-attachments/assets/edccc97c-ebbc-4d04-be79-5a822c343fad" />

## ember serve --help
<img width="660" height="621" alt="image" src="https://github.com/user-attachments/assets/41705a39-08c2-4396-8804-4fe2a663490b" />
